### PR TITLE
Handle missing values in a request

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -100,8 +100,8 @@ func (s *Server) handleLog() http.HandlerFunc {
 
 		// Process the request
 		req := &Request{
-			Text:      r.Form["text"][0],
-			UserID:    r.Form["user_id"][0],
+			Text:      r.FormValue("text"),
+			UserID:    r.FormValue("user_id"),
 			Timestamp: r.Header.Get("X-Slack-Request-Timestamp"),
 			Area:      s.Config.Area,
 			DB:        s.database,


### PR DESCRIPTION
Instead of slicing a list (causing a panic), we just call FormValue that
will either return the actual value or an empty string.

Signed-off-by: Lester James V. Miranda <ljvmiranda@gmail.com>